### PR TITLE
Returning true from the listener to stop preventing document's clicks

### DIFF
--- a/src/angular-date-range-picker.coffee
+++ b/src/angular-date-range-picker.coffee
@@ -226,6 +226,7 @@ angular.module("dateRangePicker").directive "dateRangePicker", ["$compile", ($co
 
     angular.element(document).bind "click", (e) ->
       $scope.$apply -> $scope.hide()
+      true
 
     _makeQuickList()
     _calculateRange()


### PR DESCRIPTION
The document click listener method returns false becase $scope.hide() method returns its last expression which evaluates to 'false'. Returning true fixes the problem.
